### PR TITLE
Improve reference handling

### DIFF
--- a/src/link-generator.ts
+++ b/src/link-generator.ts
@@ -196,7 +196,7 @@ export function addLinkDefinitions(oas: OpenAPIV3.Document): { oas: OpenAPIV3.Do
     if (toGet.operationId != null) {
       operationId = toGet.operationId;
     } else {
-      operationRef = serializeJsonPointer(['paths', potLink.from, 'get']);
+      operationRef = '#' + serializeJsonPointer(['paths', potLink.from, 'get']);
     }
     const linkDefinition = {
       description: `Automatically generated link definition`,
@@ -252,7 +252,7 @@ export function addLinkDefinitions(oas: OpenAPIV3.Document): { oas: OpenAPIV3.Do
           dedupLinkName += '1';
         }
         response.links[dedupLinkName] = {
-          $ref: serializeJsonPointer(['components', 'links', referenceName])
+          $ref: '#' + serializeJsonPointer(['components', 'links', referenceName])
         };
         numAddedLinks++;
       });

--- a/src/link-generator.ts
+++ b/src/link-generator.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import log from 'loglevel';
 import { OpenAPIV3 } from 'openapi-types';
-import { resolveComponentRef, sanitizeComponentName, serializeJsonPointer } from './openapi-tools';
+import { isExternalRef, resolveComponentRef, sanitizeComponentName, serializeJsonPointer } from './openapi-tools';
 
 interface PotentialLink {
   // The from and to strings are paths in the oas
@@ -75,6 +75,75 @@ function dereferenceParameters(
 }
 
 /**
+ * Check if two schema objects describe the same schema. This is done as follows:
+ * If both schemas are references and contain the same URI, we consider them equal.
+ * If exactly one schema is an external reference, we consider them not equal.
+ * Otherwise, we derefence internal references and consider the schemas equal
+ * if they contain the same properties with the same values.
+ *
+ * @param oas The OpenAPI document
+ * @param firstSchema The first schema or reference to check
+ * @param secondSchema The second schema or reference to check
+ */
+function areSchemasMatching(
+  oas: OpenAPIV3.Document,
+  firstSchema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
+  secondSchema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
+): boolean {
+  // If both schemas are undefined, we assume they are matching
+  if (firstSchema == null && secondSchema == null) {
+    return true;
+  }
+  // At this point, at most one schema can be undefined and the other is not
+  if (firstSchema == null || secondSchema == null) {
+    return false;
+  }
+
+  if ('$ref' in firstSchema && '$ref' in secondSchema) {
+    // If we have two references, external or internal, we only check if they are equal
+    return firstSchema.$ref === secondSchema.$ref;
+  }
+
+  // At this point at least one of the schemas is not a reference. If one is a reference
+  // we require it to be internal because we currently do not parse external references.
+  for (const param of [firstSchema, secondSchema]) {
+    if ('$ref' in param && isExternalRef(param)) {
+      return false;
+    }
+  }
+
+  // Resolve the remaining internal schema references
+  const first = '$ref' in firstSchema ? resolveComponentRef(oas, firstSchema, 'schemas') : firstSchema;
+  const second = '$ref' in secondSchema ? resolveComponentRef(oas, secondSchema, 'schemas') : secondSchema;
+
+  // Check if the schemas are equal
+  return _.isEqual(first, second);
+}
+
+/**
+ * Check if two parameter objects can be considered equal. To do that, we use a simple heuristic: *
+ * We assume that parameters with the same name and same schema have identical meaning across different
+ * operations. This heuristic is implemented in this function.
+ *
+ * @param oas The OpenAPI document
+ * @param firstParameter The first parameter to check
+ * @param secondParameter The second parameter to check
+ */
+function areParametersMatching(
+  oas: OpenAPIV3.Document,
+  firstParameter: OpenAPIV3.ParameterObject,
+  secondParameter: OpenAPIV3.ParameterObject
+): boolean {
+  // Check if the names are equal
+  if (firstParameter.name !== secondParameter.name) {
+    return false;
+  }
+
+  // Check if the schemas are equal
+  return areSchemasMatching(oas, firstParameter.schema, secondParameter.schema);
+}
+
+/**
  * Filter the list of potential links by looking at the parameters.
  * To do this, we assume that parameters of different paths with same name and schema have the same meaning.
  *
@@ -94,52 +163,67 @@ function processLinkParameters(oas: OpenAPIV3.Document, links: PotentialLink[]):
     const toPath = oas.paths[link.to];
     const toGet = toPath.get as OpenAPIV3.OperationObject;
 
-    // Create parameter lists incorporating the path and the operation parameters
-    const fromParams = fromGet.parameters != null ? dereferenceParameters(oas, fromGet.parameters) : [];
-    if (fromPath.parameters != null) {
-      fromParams.push(
-        // Filter overriden parameters
-        ...dereferenceParameters(oas, fromPath.parameters).filter(param =>
-          fromParams.every(innerParam => innerParam.name !== param.name)
-        )
+    // Check if there is any external parameter reference in the to-path. If yes, we drop this link candidate as
+    // we currently can not handle external references.
+    if (
+      [...(toGet.parameters || []), ...(toPath.parameters || [])].some(
+        parameter => '$ref' in parameter && isExternalRef(parameter)
+      )
+    ) {
+      log.debug(`  Dropping link candidate due to external parameter reference: '${link.from}' => '${link.to}'`);
+    } else {
+      // Create parameter lists incorporating the path and the operation parameters.
+      // At this point, we know that there are no external references in the to-path. We filter out all
+      // the external references from the from-path.
+      const fromParams = dereferenceParameters(
+        oas,
+        (fromGet.parameters || []).filter(param => !('$ref' in param && isExternalRef(param)))
       );
-    }
-    const toParams = toGet.parameters != null ? dereferenceParameters(oas, toGet.parameters) : [];
-    if (toPath.parameters != null) {
-      toParams.push(
-        // Filter overriden parameters
-        ...dereferenceParameters(oas, toPath.parameters).filter(param =>
-          toParams.every(innerParam => innerParam.name !== param.name)
-        )
-      );
-    }
-
-    // Ignore cookie parameters as they are assumed to be automatically conveyed
-    _.remove(toParams, parameter => parameter.in === 'cookie');
-    _.remove(fromParams, parameter => parameter.in === 'cookie');
-
-    // We use a simple heuristic: We assume that parameters with the same name and same schema have identical meaning
-    // across different operations. Therefore, we filter the potential links where all parameters for the to-operation
-    // are already given by the from operation.
-    const parameterMap = new Map<OpenAPIV3.ParameterObject, OpenAPIV3.ParameterObject>();
-    const valid = toParams.every(toParam => {
-      // If both schema-definitions are null the equality check also succeeds
-      const fromParam = fromParams.find(p => p.name === toParam.name && _.isEqual(p.schema, toParam.schema));
-      if (fromParam != null) {
-        parameterMap.set(fromParam, toParam);
-        return true;
-      } else {
-        // We have not found a matching from-parameter. However, we do not need one if the parameter is optional.
-        return toParam.required == null || toParam.required === false;
+      if (fromPath.parameters != null) {
+        fromParams.push(
+          // Filter overriden parameters
+          ...dereferenceParameters(oas, fromPath.parameters).filter(param =>
+            fromParams.every(innerParam => innerParam.name !== param.name)
+          )
+        );
       }
-    });
+      const toParams = dereferenceParameters(oas, toGet.parameters || []);
+      if (toPath.parameters != null) {
+        toParams.push(
+          // Filter overriden parameters
+          ...dereferenceParameters(oas, toPath.parameters).filter(param =>
+            toParams.every(innerParam => innerParam.name !== param.name)
+          )
+        );
+      }
 
-    if (valid) {
-      newLinks.push({
-        ...link,
-        parameterMap
+      // Ignore cookie parameters as they are assumed to be automatically conveyed
+      _.remove(toParams, parameter => parameter.in === 'cookie');
+      _.remove(fromParams, parameter => parameter.in === 'cookie');
+
+      // We use a simple heuristic: We assume that parameters with the same name and same schema have identical meaning
+      // across different operations. Therefore, we filter the potential links where all parameters for the to-operation
+      // are already given by the from operation.
+      const parameterMap = new Map<OpenAPIV3.ParameterObject, OpenAPIV3.ParameterObject>();
+      const valid = toParams.every(toParam => {
+        // If both schema-definitions are null the equality check also succeeds
+        const fromParam = fromParams.find(p => areParametersMatching(oas, toParam, p));
+        if (fromParam != null) {
+          parameterMap.set(fromParam, toParam);
+          return true;
+        } else {
+          // We have not found a matching from-parameter. However, we do not need one if the parameter is optional.
+          return toParam.required == null || toParam.required === false;
+        }
       });
-      log.debug(`  Valid link candidate found: '${link.from}' => '${link.to}', ${parameterMap.size} parameter(s)`);
+
+      if (valid) {
+        newLinks.push({
+          ...link,
+          parameterMap
+        });
+        log.debug(`  Valid link candidate found: '${link.from}' => '${link.to}', ${parameterMap.size} parameter(s)`);
+      }
     }
   }
 

--- a/test/fixtures/openapi-duplicate-schema.json
+++ b/test/fixtures/openapi-duplicate-schema.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1"
+  },
+  "paths": {
+    "/get": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TestParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/get/extension": {
+      "get": {
+        "operationId": "getextension",
+        "parameters": [
+          {
+            "name": "testparameter",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "TestParameter": {
+        "name": "testparameter",
+        "in": "query",
+        "schema": {
+          "$ref": "#/components/schemas/TestSchema"
+        }
+      }
+    },
+    "schemas": {
+      "TestSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/openapi-external-reference.json
+++ b/test/fixtures/openapi-external-reference.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1"
+  },
+  "paths": {
+    "/get": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "http://example.com/openapi.json#/components/parameters/TestParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/get/invalid": {
+      "get": {
+        "operationId": "getinvalid",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/TestSchema"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/get/parameterless": {
+      "get": {
+        "operationId": "getparameterless",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/get/valid": {
+      "get": {
+        "operationId": "getvalid",
+        "parameters": [
+          {
+            "$ref": "http://example.com/openapi.json#/components/parameters/TestParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TestSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "creationDate": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/link-generator.spec.ts
+++ b/test/link-generator.spec.ts
@@ -1,230 +1,261 @@
 import oasValidator from 'oas-validator';
 import { OpenAPIV3 } from 'openapi-types';
 import { addLinkDefinitions } from '../src/link-generator';
-import { loadOpenAPIDocument } from '../src/openapi-tools';
 
 describe('addLinkDefinitions', () => {
-  let oas: OpenAPIV3.Document;
-  let oasSubstring: OpenAPIV3.Document;
+  describe('openapi-reqbaz.json', () => {
+    let oas: OpenAPIV3.Document;
 
-  beforeEach(async () => {
-    oas = await loadOpenAPIDocument('test/fixtures/openapi-reqbaz.json', 'utf8');
-    oasSubstring = await loadOpenAPIDocument('test/fixtures/openapi-substring.json', 'utf8');
-  });
-
-  it('clones the oas-object', () => {
-    const res = addLinkDefinitions(oas).oas;
-    expect(res).not.toBe(oas);
-  });
-
-  it('returns a valid oas', async () => {
-    const res = addLinkDefinitions(oas).oas;
-    expect((await oasValidator.validate(res, {})).valid).toBe(true);
-  });
-
-  it('does not remove/overwrite any property', () => {
-    const res = addLinkDefinitions(oas).oas;
-
-    const catResponses = ((res.paths['/categories/{categoryId}'] as OpenAPIV3.PathItemObject)
-      .get as OpenAPIV3.OperationObject).responses as OpenAPIV3.ResponsesObject;
-    delete (catResponses['200'] as OpenAPIV3.ResponseObject).links;
-    delete (catResponses['203'] as OpenAPIV3.ResponseObject).links;
-    delete ((((res.paths['/projects/{projectId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
-      .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links;
-    delete ((((res.paths['/requirements/{requirementId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
-      .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links;
-    delete (res.components as OpenAPIV3.ComponentsObject).links;
-
-    expect(res).toStrictEqual(oas);
-  });
-
-  it('adds the desired link definitions', () => {
-    const res = addLinkDefinitions(oas).oas;
-
-    const catExpected = {
-      contributors: {
-        $ref: '#/components/links/contributors'
-      },
-      followers: {
-        $ref: '#/components/links/followers'
-      },
-      requirements: {
-        $ref: '#/components/links/requirements'
-      },
-      statistics: {
-        $ref: '#/components/links/statistics'
-      }
-    };
-    const catResponses = ((res.paths['/categories/{categoryId}'] as OpenAPIV3.PathItemObject)
-      .get as OpenAPIV3.OperationObject).responses as OpenAPIV3.ResponsesObject;
-    expect((catResponses['200'] as OpenAPIV3.ResponseObject).links).toStrictEqual(catExpected);
-    expect((catResponses['203'] as OpenAPIV3.ResponseObject).links).toStrictEqual(catExpected);
-
-    expect(
-      ((((res.paths['/projects/{projectId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
-        .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links
-    ).toStrictEqual({
-      categories: {
-        description: expect.any(String),
-        operationRef: '#/paths/~1projects~1{projectId}/get',
-        parameters: {
-          projectId: '$request.path.projectId'
-        }
-      },
-      contributors: {
-        description: expect.any(String),
-        operationId: 'getContributorsForProject',
-        parameters: {
-          projectId: '$request.path.projectId'
-        }
-      },
-      followers: {
-        description: expect.any(String),
-        operationId: 'getFollowersForProject',
-        parameters: {
-          projectId: '$request.path.projectId'
-        }
-      },
-      requirements: {
-        description: expect.any(String),
-        operationId: 'getRequirementsForProject',
-        parameters: {
-          projectId: '$request.path.projectId'
-        }
-      },
-      statistics: {
-        description: expect.any(String),
-        operationId: 'getStatisticsForProject',
-        parameters: {
-          projectId: '$request.path.projectId'
-        }
-      }
+    beforeEach(() => {
+      oas = require('./fixtures/openapi-reqbaz.json');
     });
 
-    expect(
-      ((((res.paths['/requirements/{requirementId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
-        .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links
-    ).toStrictEqual({
-      attachments: {
-        description: expect.any(String),
-        operationId: 'getAttachmentsForRequirement',
-        parameters: {
-          requirementId: '$request.path.requirementId'
-        }
-      },
-      comments: {
-        description: expect.any(String),
-        operationId: 'getCommentsForRequirement',
-        parameters: {
-          requirementId: '$request.path.requirementId'
-        }
-      },
-      contributors: {
-        description: expect.any(String),
-        operationId: 'getContributorsForRequirement',
-        parameters: {
-          requirementId: '$request.path.requirementId'
-        }
-      },
-      developers: {
-        description: expect.any(String),
-        operationId: 'getDevelopersForRequirement',
-        parameters: {
-          requirementId: '$request.path.requirementId'
-        }
-      },
-      followers: {
-        description: expect.any(String),
-        operationId: 'getFollowersForRequirement',
-        parameters: {
-          requirementId: '$request.path.requirementId'
-        }
-      },
-      statistics: {
-        description: expect.any(String),
-        operationId: 'getStatisticsForRequirement',
-        parameters: {
-          requirementId: '$request.path.requirementId'
-        }
-      }
+    it('clones the oas-object', () => {
+      const res = addLinkDefinitions(oas).oas;
+      expect(res).not.toBe(oas);
     });
 
-    expect((res.components as OpenAPIV3.ComponentsObject).links).toStrictEqual({
-      contributors: {
-        description: expect.any(String),
-        operationId: 'getContributorsForCategory',
-        parameters: {
-          categoryId: '$request.path.categoryId'
-        }
-      },
-      followers: {
-        description: expect.any(String),
-        operationId: 'getFollowersForCategory',
-        parameters: {
-          categoryId: '$request.path.categoryId'
-        }
-      },
-      requirements: {
-        description: expect.any(String),
-        operationId: 'getRequirementsForCategory',
-        parameters: {
-          categoryId: '$request.path.categoryId'
-        }
-      },
-      statistics: {
-        description: expect.any(String),
-        operationId: 'getStatisticsForCategory',
-        parameters: {
-          categoryId: '$request.path.categoryId'
-        }
-      }
+    it('returns a valid oas', async () => {
+      const res = addLinkDefinitions(oas).oas;
+      expect((await oasValidator.validate(res, {})).valid).toBe(true);
     });
-  });
 
-  it('does not overwrite existing links', () => {
-    const attLink = {
-      description: 'Test description',
-      operationId: 'abc',
-      parameters: {
-        requirementId: 'defg'
-      }
-    };
+    it('does not remove/overwrite any property', () => {
+      const res = addLinkDefinitions(oas).oas;
 
-    ((((oas.paths['/requirements/{requirementId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
-      .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links = {
-      attachments: attLink
-    };
+      const catResponses = ((res.paths['/categories/{categoryId}'] as OpenAPIV3.PathItemObject)
+        .get as OpenAPIV3.OperationObject).responses as OpenAPIV3.ResponsesObject;
+      delete (catResponses['200'] as OpenAPIV3.ResponseObject).links;
+      delete (catResponses['203'] as OpenAPIV3.ResponseObject).links;
+      delete ((((res.paths['/projects/{projectId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
+        .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links;
+      delete ((((res.paths['/requirements/{requirementId}'] as OpenAPIV3.PathItemObject)
+        .get as OpenAPIV3.OperationObject).responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject)
+        .links;
+      delete (res.components as OpenAPIV3.ComponentsObject).links;
 
-    const res = addLinkDefinitions(oas).oas;
-    expect(
-      ((((res.paths['/requirements/{requirementId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
-        .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links
-    ).toMatchObject({
-      attachments: attLink
+      expect(res).toStrictEqual(oas);
     });
-  });
 
-  it('does not overwrite existing link components', () => {
-    const link = {
-      description: 'Test description',
-      operationId: 'def',
-      parameters: {
-        categoryId: 'fed'
-      }
-    };
+    it('adds the desired link definitions', () => {
+      const res = addLinkDefinitions(oas).oas;
 
-    (oas.components as OpenAPIV3.ComponentsObject).links = {
-      contributors: link
-    };
+      const catExpected = {
+        contributors: {
+          $ref: '#/components/links/contributors'
+        },
+        followers: {
+          $ref: '#/components/links/followers'
+        },
+        requirements: {
+          $ref: '#/components/links/requirements'
+        },
+        statistics: {
+          $ref: '#/components/links/statistics'
+        }
+      };
+      const catResponses = ((res.paths['/categories/{categoryId}'] as OpenAPIV3.PathItemObject)
+        .get as OpenAPIV3.OperationObject).responses as OpenAPIV3.ResponsesObject;
+      expect((catResponses['200'] as OpenAPIV3.ResponseObject).links).toStrictEqual(catExpected);
+      expect((catResponses['203'] as OpenAPIV3.ResponseObject).links).toStrictEqual(catExpected);
 
-    const res = addLinkDefinitions(oas).oas;
-    expect((res.components as OpenAPIV3.ComponentsObject).links).toMatchObject({
-      contributors: link
+      expect(
+        ((((res.paths['/projects/{projectId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
+          .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links
+      ).toStrictEqual({
+        categories: {
+          description: expect.any(String),
+          operationRef: '#/paths/~1projects~1{projectId}/get',
+          parameters: {
+            projectId: '$request.path.projectId'
+          }
+        },
+        contributors: {
+          description: expect.any(String),
+          operationId: 'getContributorsForProject',
+          parameters: {
+            projectId: '$request.path.projectId'
+          }
+        },
+        followers: {
+          description: expect.any(String),
+          operationId: 'getFollowersForProject',
+          parameters: {
+            projectId: '$request.path.projectId'
+          }
+        },
+        requirements: {
+          description: expect.any(String),
+          operationId: 'getRequirementsForProject',
+          parameters: {
+            projectId: '$request.path.projectId'
+          }
+        },
+        statistics: {
+          description: expect.any(String),
+          operationId: 'getStatisticsForProject',
+          parameters: {
+            projectId: '$request.path.projectId'
+          }
+        }
+      });
+
+      expect(
+        ((((res.paths['/requirements/{requirementId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
+          .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links
+      ).toStrictEqual({
+        attachments: {
+          description: expect.any(String),
+          operationId: 'getAttachmentsForRequirement',
+          parameters: {
+            requirementId: '$request.path.requirementId'
+          }
+        },
+        comments: {
+          description: expect.any(String),
+          operationId: 'getCommentsForRequirement',
+          parameters: {
+            requirementId: '$request.path.requirementId'
+          }
+        },
+        contributors: {
+          description: expect.any(String),
+          operationId: 'getContributorsForRequirement',
+          parameters: {
+            requirementId: '$request.path.requirementId'
+          }
+        },
+        developers: {
+          description: expect.any(String),
+          operationId: 'getDevelopersForRequirement',
+          parameters: {
+            requirementId: '$request.path.requirementId'
+          }
+        },
+        followers: {
+          description: expect.any(String),
+          operationId: 'getFollowersForRequirement',
+          parameters: {
+            requirementId: '$request.path.requirementId'
+          }
+        },
+        statistics: {
+          description: expect.any(String),
+          operationId: 'getStatisticsForRequirement',
+          parameters: {
+            requirementId: '$request.path.requirementId'
+          }
+        }
+      });
+
+      expect((res.components as OpenAPIV3.ComponentsObject).links).toStrictEqual({
+        contributors: {
+          description: expect.any(String),
+          operationId: 'getContributorsForCategory',
+          parameters: {
+            categoryId: '$request.path.categoryId'
+          }
+        },
+        followers: {
+          description: expect.any(String),
+          operationId: 'getFollowersForCategory',
+          parameters: {
+            categoryId: '$request.path.categoryId'
+          }
+        },
+        requirements: {
+          description: expect.any(String),
+          operationId: 'getRequirementsForCategory',
+          parameters: {
+            categoryId: '$request.path.categoryId'
+          }
+        },
+        statistics: {
+          description: expect.any(String),
+          operationId: 'getStatisticsForCategory',
+          parameters: {
+            categoryId: '$request.path.categoryId'
+          }
+        }
+      });
+    });
+
+    it('does not overwrite existing links', () => {
+      const attLink = {
+        description: 'Test description',
+        operationId: 'abc',
+        parameters: {
+          requirementId: 'defg'
+        }
+      };
+
+      ((((oas.paths['/requirements/{requirementId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
+        .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links = {
+        attachments: attLink
+      };
+
+      const res = addLinkDefinitions(oas).oas;
+      expect(
+        ((((res.paths['/requirements/{requirementId}'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
+          .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links
+      ).toMatchObject({
+        attachments: attLink
+      });
+    });
+
+    it('does not overwrite existing link components', () => {
+      const link = {
+        description: 'Test description',
+        operationId: 'def',
+        parameters: {
+          categoryId: 'fed'
+        }
+      };
+
+      (oas.components as OpenAPIV3.ComponentsObject).links = {
+        contributors: link
+      };
+
+      const res = addLinkDefinitions(oas).oas;
+      expect((res.components as OpenAPIV3.ComponentsObject).links).toMatchObject({
+        contributors: link
+      });
     });
   });
 
   it('does detect path extension instead of substring', () => {
+    const oasSubstring = require('./fixtures/openapi-substring.json');
     // Paths of the form /A and /A/B should be linked. Paths of the form /A, /AB not.
     expect(addLinkDefinitions(oasSubstring).oas).toStrictEqual(oasSubstring);
+  });
+
+  it('handles external references', () => {
+    const oas = require('./fixtures/openapi-external-reference.json') as OpenAPIV3.Document;
+    const res = addLinkDefinitions(oas).oas;
+
+    expect(
+      ((((res.paths['/get'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
+        .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links
+    ).toMatchObject({
+      parameterless: {
+        operationId: 'getparameterless',
+        parameters: {}
+      }
+    });
+  });
+
+  it('handles duplicate parameter and schema definitions', () => {
+    const oas = require('./fixtures/openapi-duplicate-schema.json') as OpenAPIV3.Document;
+    const res = addLinkDefinitions(oas).oas;
+
+    expect(
+      ((((res.paths['/get'] as OpenAPIV3.PathItemObject).get as OpenAPIV3.OperationObject)
+        .responses as OpenAPIV3.ResponsesObject)['200'] as OpenAPIV3.ResponseObject).links
+    ).toMatchObject({
+      extension: {
+        operationId: 'getextension',
+        parameters: { testparameter: '$request.query.testparameter' }
+      }
+    });
   });
 });

--- a/test/openapi-tools.spec.ts
+++ b/test/openapi-tools.spec.ts
@@ -156,6 +156,30 @@ describe('resolveComponentRef', () => {
     expect(() => resolveComponentRef(doc, { $ref: '#/components/responses/TestResponse' }, 'schemas')).toThrow();
     expect(() => resolveComponentRef(doc, { $ref: '#/components/responses/TestResponse' }, 'parameters')).toThrow();
   });
+
+  it('should fail on external references', () => {
+    expect(() =>
+      resolveComponentRef(
+        doc,
+        { $ref: 'https://example.com/openapi.json#/components/schemas/SchemaReference' },
+        'parameters'
+      )
+    ).toThrow();
+    expect(() =>
+      resolveComponentRef(
+        doc,
+        { $ref: 'https://example.com/openapi.json#/components/schemas/SchemaReference' },
+        'responses'
+      )
+    ).toThrow();
+    expect(() =>
+      resolveComponentRef(
+        doc,
+        { $ref: 'https://example.com/openapi.json#/components/schemas/SchemaReference' },
+        'schemas'
+      )
+    ).toThrow();
+  });
 });
 
 describe('sanitizeComponentName', () => {
@@ -176,31 +200,31 @@ describe('sanitizeComponentName', () => {
 
 describe('serializeJsonPointer', () => {
   it('assembles paths correctly', () => {
-    expect(serializeJsonPointer(['components', 'abc'])).toBe('#/components/abc');
-    expect(serializeJsonPointer(['abc'])).toBe('#/abc');
+    expect(serializeJsonPointer(['components', 'abc'])).toBe('/components/abc');
+    expect(serializeJsonPointer(['abc'])).toBe('/abc');
   });
 
   it('escapes characters correctly', () => {
-    expect(serializeJsonPointer(['/components', '~ab-c'])).toBe('#/~1components/~0ab-c');
-    expect(serializeJsonPointer(['c/o~mp', '~~ab~//'])).toBe('#/c~1o~0mp/~0~0ab~0~1~1');
-    expect(serializeJsonPointer(['!"§$%&()=?*^°`´$%/|~'])).toBe('#/!"§$%&()=?*^°`´$%~1|~0');
+    expect(serializeJsonPointer(['/components', '~ab-c'])).toBe('/~1components/~0ab-c');
+    expect(serializeJsonPointer(['c/o~mp', '~~ab~//'])).toBe('/c~1o~0mp/~0~0ab~0~1~1');
+    expect(serializeJsonPointer(['!"§$%&()=?*^°`´$%/|~'])).toBe('/!"§$%&()=?*^°`´$%~1|~0');
   });
 
   it('handles empty paths', () => {
-    expect(serializeJsonPointer([])).toBe('#/');
+    expect(serializeJsonPointer([])).toBe('/');
   });
 });
 
 describe('parseJsonPointer', () => {
   it('splits paths correctly', () => {
-    expect(parseJsonPointer('#/components/abc')).toEqual(['components', 'abc']);
-    expect(parseJsonPointer('#/')).toEqual([]);
+    expect(parseJsonPointer('/components/abc')).toEqual(['components', 'abc']);
+    expect(parseJsonPointer('/')).toEqual([]);
   });
 
   it('parses control characters', () => {
-    expect(parseJsonPointer('#/~1components/~0ab-c')).toEqual(['/components', '~ab-c']);
-    expect(parseJsonPointer('#/c~1o~0mp/~0~0ab~0~1~1')).toEqual(['c/o~mp', '~~ab~//']);
-    expect(parseJsonPointer('#/!"§$%&()=?*^°`´$%~1|~0')).toEqual(['!"§$%&()=?*^°`´$%/|~']);
+    expect(parseJsonPointer('/~1components/~0ab-c')).toEqual(['/components', '~ab-c']);
+    expect(parseJsonPointer('/c~1o~0mp/~0~0ab~0~1~1')).toEqual(['c/o~mp', '~~ab~//']);
+    expect(parseJsonPointer('/!"§$%&()=?*^°`´$%~1|~0')).toEqual(['!"§$%&()=?*^°`´$%/|~']);
   });
 
   it('throws on non-local pointers', () => {


### PR DESCRIPTION
Improve handling of Reference Objects. This includes:
- Refactor the serialize/deserialize JSON Pointer functions to match the OpenAPI specifications definition of Reference Objects ([Link](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#referenceObject))
- Gracefully handle References to external OpenAPI documents. As we do not want to fetch and parse the externally referenced documents, we simply ignore those references.